### PR TITLE
Reproduce #28

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <extends src="./container.html">
   <block name="grid-children">
     <extends src="./column.html">
-      <block name="grid-children">
+      <block name="col-children">
         <div>this breaks</div>
       </block>
     </extends>


### PR DESCRIPTION
I think the example @AdamDemirel provided in https://github.com/posthtml/posthtml-extend/issues/28 has a typo. The issue arises when you use nested extends with different block names.

```
❯ node index.js
(node:31505) UnhandledPromiseRejectionWarning: Error: [posthtml-extend] Unexpected block "col-children"
    at getError (/Users/bkeepers/projects/posthtml-extend-issues-28/node_modules/posthtml-extend/lib/extend.js:228:12)
    at mergeExtendsAndLayout (/Users/bkeepers/projects/posthtml-extend-issues-28/node_modules/posthtml-extend/lib/extend.js:156:23)
    at /Users/bkeepers/projects/posthtml-extend-issues-28/node_modules/posthtml-extend/lib/extend.js:91:31
    at /Users/bkeepers/projects/posthtml-extend-issues-28/node_modules/posthtml/lib/api.js:91:45
    at traverse (/Users/bkeepers/projects/posthtml-extend-issues-28/node_modules/posthtml/lib/api.js:105:26)
    at Array.match (/Users/bkeepers/projects/posthtml-extend-issues-28/node_modules/posthtml/lib/api.js:90:7)
    at handleExtendsNodes (/Users/bkeepers/projects/posthtml-extend-issues-28/node_modules/posthtml-extend/lib/extend.js:81:16)
    at /Users/bkeepers/projects/posthtml-extend-issues-28/node_modules/posthtml-extend/lib/extend.js:45:16
    at /Users/bkeepers/projects/posthtml-extend-issues-28/node_modules/posthtml/lib/index.js:216:14
    at tryCatch (/Users/bkeepers/projects/posthtml-extend-issues-28/node_modules/posthtml/lib/index.js:299:12)
```